### PR TITLE
feat(docs): add local search configuration 

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -41,6 +41,10 @@ export default defineConfig({
 
     socialLinks: [
       { icon: 'github', link: 'https://github.com/e2tmk/hunter' }
-    ]
+    ],
+
+    search: {
+      provider: "local"
+    }
   }
 })


### PR DESCRIPTION
This pull request updates the VitePress configuration to include a local search provider.

* [`docs/.vitepress/config.mts`](diffhunk://#diff-e3dd2227e911b905c0de197c1154f07c408373635ac0434607068133835e88deL44-R48): Added a `search` configuration with the `provider` set to `"local"`.